### PR TITLE
Fix bug where 11ty tries to write a tag folder with an illegal character

### DIFF
--- a/tags.njk
+++ b/tags.njk
@@ -13,7 +13,7 @@ pagination:
 layout: layouts/home.njk
 eleventyComputed:
   title: Tagged “{{ tag }}”
-permalink: /tags/{{ tag }}/
+permalink: /tags/{{ tag | slug }}/
 ---
 
 {% set postslist = collections[ tag ] %}


### PR DESCRIPTION
e.g. if I tag something `c#`, 11ty tries to write a folder named `tags\c#` which is illegal depending on what OS is used.